### PR TITLE
fix: Npx prisma error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN npm ci --include=dev
 COPY --link . .
 
 # Generate Prisma Client.
-RUN npx prisma generate
+RUN npx prisma@5.18.0 generate
 
 # Build application
 RUN npm run build

--- a/docker-entrypoint.js
+++ b/docker-entrypoint.js
@@ -7,7 +7,7 @@ const env = { ...process.env };
 (async () => {
   // If running the web server then migrate existing database
   if (process.argv.slice(2).join(' ') === 'node server.js') {
-    await exec('npx prisma migrate deploy');
+    await exec('npx prisma@5.18.0 migrate deploy');
   }
 
   // launch application


### PR DESCRIPTION
Specific version of Prisma was not being specified in the Dockerfile or entrypoint file which meant that the latest version was being downloaded which required a higher version of Node.js and was resulting in an error. Fix is to specify specific version of Prisma which is compatible with Node version being used.